### PR TITLE
Added mailbox test for RTEMS

### DIFF
--- a/rtps-r52/init.c
+++ b/rtps-r52/init.c
@@ -444,7 +444,8 @@ void *POSIX_Init(void *arg)
     &shell_cmd_test_link_shmem, \
     /* externally-dependent tests */ \
     &shell_cmd_test_link_mbox_trch, \
-    &shell_cmd_test_link_shmem_trch
+    &shell_cmd_test_link_shmem_trch, \
+    &shell_cmd_test_mbox_rtps_hpps
 #include <rtems/shellconfig.h>
 
 /* drivers */

--- a/rtps-r52/shell-tests.c
+++ b/rtps-r52/shell-tests.c
@@ -204,3 +204,27 @@ rtems_shell_cmd_t shell_cmd_test_link_shmem_trch = {
     NULL, NULL,                                /* alias, next */
     0, 0, 0                                    /* mode, uid, gid */
 };
+
+static int shell_test_mbox_rtps_hpps(int argc RTEMS_UNUSED,
+                                         char *argv[] RTEMS_UNUSED)
+{
+    if (argc <= 1) {
+        fprintf(stderr, "ERROR: TEST REQUIRES 2 MBOXES\n");
+        return -1;
+    }
+
+    unsigned mbox_in = atoi(argv[1]);
+    unsigned mbox_out = atoi(argv[2]);
+
+    return test_mbox_rtps_hpps(mbox_in, mbox_out);
+}
+rtems_shell_cmd_t shell_cmd_test_mbox_rtps_hpps = {
+    "test_mbox_rtps_hpps",                          /* name */
+    "test_mbox_rtps_hpps",                          /* usage */
+    SHELL_TESTS_TOPIC,                              /* topic */
+    shell_test_mbox_rtps_hpps,                      /* command */
+    NULL, NULL,                                     /* alias, next */
+    0, 0, 0                                         /* mode, uid, gid */
+};
+
+

--- a/rtps-r52/shell-tests.h
+++ b/rtps-r52/shell-tests.h
@@ -24,4 +24,6 @@ extern rtems_shell_cmd_t shell_cmd_test_link_shmem;
 extern rtems_shell_cmd_t shell_cmd_test_link_mbox_trch;
 extern rtems_shell_cmd_t shell_cmd_test_link_shmem_trch;
 
+extern rtems_shell_cmd_t shell_cmd_test_mbox_rtps_hpps;
+
 #endif // SHELL_TESTS_H

--- a/rtps-r52/test.h
+++ b/rtps-r52/test.h
@@ -32,6 +32,8 @@ int test_link_shmem(void);
 int test_link_mbox_trch(void);
 int test_link_shmem_trch(void);
 
+int test_mbox_rtps_hpps(unsigned mbox_in, unsigned mbox_out);
+
 // test utilities
 
 RTEMS_INLINE_ROUTINE void test_begin(const char *name)

--- a/rtps-r52/tests/mailbox.c
+++ b/rtps-r52/tests/mailbox.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <string.h>
 
 // plat
 #include <mailbox-map.h>
@@ -11,8 +12,13 @@
 
 // libhpsc
 #include <devices.h>
+#include <link-mbox.h>
+#include <link.h>
+#include <hpsc-msg.h>
 
 #include "test.h"
+
+#define SEND_RCV_TIME_OUT 3567587328
 
 int test_mbox_lsio_loopback(void)
 {
@@ -24,5 +30,53 @@ int test_mbox_lsio_loopback(void)
                              LSIO_MBOX0_CHAN__RTPS_R52_LOCKSTEP_SSW__LOOPBACK,
                              /* owner */ 0, /* src */ 0, /* dest */ 0);
     test_end("test_mbox_lsio_loopback", rc);
+    return rc;
+}
+
+int test_mbox_rtps_hpps(unsigned mbox_in, unsigned mbox_out){
+
+    enum hpsc_mbox_test_rc rc = HPSC_MBOX_TEST_SUCCESS;
+
+    test_begin("test_mbox_rtps_hpps");
+
+    if (mbox_in >= HPSC_MBOX_CHANNELS || mbox_out >= HPSC_MBOX_CHANNELS) {
+        rc = HPSC_MBOX_TEST_CHAN_CLAIM;
+        test_end("test_mbox_rtps_hpps",rc);
+        return rc;
+    }
+
+    struct hpsc_mbox *mbox_hpps = dev_get_mbox(DEV_ID_MBOX_HPPS_RTPS); 
+
+    assert(mbox_hpps);
+
+    const char* name = "TEST_LINK";
+    struct link *test_link = link_mbox_connect(name, mbox_hpps,mbox_in ,mbox_out , 0, 1); 
+    assert(link);
+
+    int bytes; //bytes read 
+
+    char write_buf [HPSC_MSG_SIZE];
+    char read_buf [HPSC_MSG_SIZE];
+    char payload[HPSC_MSG_PAYLOAD_SIZE] = { 0 };
+
+    hpsc_msg_ping(write_buf, HPSC_MSG_SIZE, payload, sizeof(payload));
+
+
+    bytes = link_request(test_link, 
+                     SEND_RCV_TIME_OUT, write_buf, sizeof(write_buf),
+                     SEND_RCV_TIME_OUT, read_buf, sizeof(read_buf),
+                     RTEMS_EVENT_2);
+
+    //send failure/timeout
+    if (bytes == -1) {
+        rc = HPSC_MBOX_TEST_CHAN_WRITE;
+    }
+    //receive timeout
+    else if (bytes == -2) {
+        rc = HPSC_MBOX_TEST_CHAN_NO_RECV;
+    }
+
+    link_disconnect(test_link);
+    test_end("test_mbox_rtps_hpps",rc);
     return rc;
 }


### PR DESCRIPTION
Added shell command in RTEMS for running a mailbox client. Run with test_mbox_rtps_hpps _MAILBOX_IN_NUMBER MAILBOX_OUT_NUMBER_ on RTEMS shell and corresponding server code (mbox-server-tester.c) on HPPS.